### PR TITLE
Update the tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -52,7 +52,7 @@ In ``projects/models.py``, define a ``Project``::
             (INACTIVE, "Inactive"),
         ]
 
-        staus = models.CharField(
+        status = models.CharField(
             max_length=2,
             choices=STATUS_CHOICES,
         )

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -63,7 +63,7 @@ In ``projects/models.py``, define a ``Project``::
             return self.status in {self.BLOCKED, self.INACTIVE}
 
         def __str__(self):
-            return self.question_text
+            return self.name
 
 
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -76,7 +76,6 @@ Then add the project, the ``projects`` module and Neapolitan to the beginning of
     INSTALLED_APPS = [
         'projects',
         'neapolitan',
-        'dashboard',
         [...]
     ]
 


### PR DESCRIPTION
I happened to be trying to do a minimal reproduction of an issue by using the new tutorial, and I came across a couple of minor issues / nitpicks.

I also wondered if maybe some parts like the 'Add some objects using the django admin' should link to other docs such as the djangoproject tutorial that goes over using the admin interface...I'm not sure if that's considered good or bad practice in this case though...? Would be happy to add that in if it makes sense.
