### PR TITLE
Add ability to change base html template

### DIFF
--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -13,6 +13,15 @@ The templates ``{% extends "base.html" %}``, which must provide
 ``{% block content %}``. Neapolitan may provide a base template in the future,
 see `issue #6 <https://github.com/carltongibson/neapolitan/issues/6>`_.
 
+You can change the base html template that neapolitan looks for by setting the
+``BASE_TEMPLATE`` in Neapolitan setting.
+
+.. code-block:: html+django
+
+    NEAPOLITAN = {
+        "BASE_TEMPLATE": "dashboard_base.html",
+    }
+
 This is the full listing of the provided templates:
 
 .. code-block:: shell

--- a/src/neapolitan/templates/neapolitan/object_confirm_delete.html
+++ b/src/neapolitan/templates/neapolitan/object_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends base_template %}
 
 {% block content %}
 

--- a/src/neapolitan/templates/neapolitan/object_detail.html
+++ b/src/neapolitan/templates/neapolitan/object_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends base_template %}
 {% load neapolitan %}
 
 {% block content %}

--- a/src/neapolitan/templates/neapolitan/object_form.html
+++ b/src/neapolitan/templates/neapolitan/object_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends base_template %}
 
 {% block content %}
 

--- a/src/neapolitan/templates/neapolitan/object_list.html
+++ b/src/neapolitan/templates/neapolitan/object_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends base_template %}
 {% load neapolitan %}
 
 {% block content %}

--- a/src/neapolitan/utils/__init__.py
+++ b/src/neapolitan/utils/__init__.py
@@ -1,0 +1,1 @@
+from .common import get_settings

--- a/src/neapolitan/utils/common.py
+++ b/src/neapolitan/utils/common.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+
+def get_settings():
+    """
+    Returns neapolitan settings defined in settings file.
+    
+    If not defined returns an empty dict.
+    """
+    try:
+        neapolitan_settings = settings.NEAPOLITAN
+    except AttributeError:
+        return {}
+    else:
+        return neapolitan_settings

--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -13,6 +13,8 @@ from django.utils.translation import gettext as _
 from django.views.generic import View
 from django_filters.filterset import filterset_factory
 
+from neapolitan.utils import get_settings
+
 
 # A CRUDView is a view that can perform all the CRUD operations on a model. The
 # `role` attribute determines which operations are available for a given
@@ -248,6 +250,7 @@ class CRUDView(View):
         kwargs["object_verbose_name"] = self.model._meta.verbose_name
         kwargs["object_verbose_name_plural"] = self.model._meta.verbose_name_plural
         kwargs["create_view_url"] = reverse(f"{self.model._meta.model_name}-create")
+        kwargs["base_template"] = self.get_base_template_name()
 
         if getattr(self, "object", None) is not None:
             kwargs["object"] = self.object
@@ -262,6 +265,15 @@ class CRUDView(View):
                 kwargs[context_object_name] = self.object_list
 
         return kwargs
+
+    def get_base_template_name(self):
+        """
+        Get base html page name.
+
+        Looks at settings and if not defined return base.html as default.
+        """
+        settings = get_settings()
+        return settings.get("BASE_TEMPLATE", "base.html")
 
     def get_template_names(self):
         """


### PR DESCRIPTION
It is not ideal that Neapolitan expects the base html template of the CRUD pages should to named `base.html`. This PR adds support to change the base html that Neapolitan looks for through settings.

- Add base html template name to context data.
- Change all template files to extend the base html template using variable passed in context data.
- Add ability to read Neapolitan settings from settings file. It expects settings to be in following format.

```
NEAPOLITAN = {
    "SETTING_NAME": "setting_value",
}
```
- Document the way to override the base template name.

I think this is what meant in step 2 of #6. In any case imo this is a must have functionality going forward.