### PR TITLE
Removed incorrect annotation for object.

### DIFF
--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -76,7 +76,7 @@ class CRUDView(View):
     # value as `lookup_field`.
     lookup_field = "pk"
     lookup_url_kwarg = None
-    object: models.Model = None
+    object = None
 
     # All the following are optional, and fall back to default values
     # based on the 'model' shortcut.


### PR DESCRIPTION
`object` should be annotated with a subclass of `Model`, depending on `model`. This isn't possible to express in the type-system, so a mypy plugin would be needed.

The annotation here was a WIP attempt to keep VS Code happy. It didn't work. (And I forgot to delete it.)

In addition though it made PyCharm/VS Code complain about custom properties/method not existing on `Model`, which of course they don't.

Removing the annotation, allows the IDEs to interpret `self.object` as `Any`, so whilst not type-checked, it removes (some) spurious noise in the editor.

The ideal code is just to set `model = MyModel` and have `object` inferred. That's what the plugin would (will?) allow.