### PR TITLE
add test GHA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,20 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         django-version: ["4.2", "5.0", "main"]
-        exclude:
-          # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-          # main requires python 3.10+
-          - django-version: "main"
-            python-version: "3.8"
-          - django-version: "main"
-            python-version: "3.9"
-          # 5.0 requires python 3.10+
-          - django-version: "5.0"
-            python-version: "3.8"
-          - django-version: "5.0"
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
 
@@ -75,7 +63,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-      PYTHON_MIN_VERSION: "3.8"
+      PYTHON_MIN_VERSION: "3.10"
       DJANGO_MIN_VERSION: "4.2"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,100 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: test-${{ github.head_ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONUNBUFFERED: "1"
+  FORCE_COLOR: "1"
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }}
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["4.2", "5.0", "main"]
+        exclude:
+          # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+          # main requires python 3.10+
+          - django-version: "main"
+            python-version: "3.8"
+          - django-version: "main"
+            python-version: "3.9"
+          # 5.0 requires python 3.10+
+          - django-version: "5.0"
+            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.9"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [[ "${{ matrix.django-version }}" == "main" ]]; then
+            python -m pip install https://github.com/django/django/archive/refs/heads/main.zip
+          else
+            python -m pip install django==${{ matrix.django-version }}
+          fi
+          python -m pip install '.[tests]'
+
+      - name: Run tests
+        run: |
+          just test
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: OK
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Fail
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_MIN_VERSION: "3.8"
+      DJANGO_MIN_VERSION: "4.2"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v1
+
+      - name: Set up Python ${{ env.PYTHON_MIN_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_MIN_VERSION }}
+          cache: "pip"
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install django==${{ env.DJANGO_MIN_VERSION }}
+          python -m pip install '.[tests]'
+
+      - name: Run coverage
+        run: |
+          just coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Docs = "https://noumenal.es/neapolitan/"
 
 [project.optional-dependencies]
 docs = ["Sphinx"]
-tests = ["coverage", "django_coverage_plugin"]
+tests = ["coverage[toml]", "django_coverage_plugin"]
 
 [tool.coverage.run]
 plugins = ["django_coverage_plugin"]


### PR DESCRIPTION
closes westerveltco/neapolitan#3

You may or may not want the entire matrix I have set up here. @jefftriplett has given me a hard time in the past because I tend to go maximalist on Westervelt's open source packages by [testing all the things](https://kagi.com/proxy/1t5hik.jpg?c=vpZRDV3HW2MylgPZZqPE4GWQsSQnkiQa6adLC5a55PnURC7jn6mF2SAvyqGm4Fw-bOYqK1jtqWnt__bY4kPBTD_YZxmiuFHkZbkeu-YEE1Y%3D) so I always test against every version of both Python and Django. Chalk it up to my relative inexperience releasing packages in to the public and wanting to cover all my bases. 🤷‍♂️

Let me know any adjustments you'd like to make. 🍻