### PR TITLE
fix_46_allow_for_missing_actions_while_rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Version numbers correspond to git tags. Please use the compare view on GitHub
 for full details. Until we're further along, I will just note the highlights
 here:
 
+24.5
+====
+
+* Fixed an error in 24.4 reversing non-routed URLs when only using a subset of roles.
+
+  Thanks to Emmanuelle Delescolle.
+
 24.4
 ====
 

--- a/src/neapolitan/templates/neapolitan/object_list.html
+++ b/src/neapolitan/templates/neapolitan/object_list.html
@@ -5,10 +5,12 @@
 
 <div class="sm:flex sm:items-center">
     <h1 class="sm:flex-auto text-base font-semibold leading-6 text-gray-900">{{ object_verbose_name_plural|capfirst }}</h1>
-    <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-        <a class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-           href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
-    </div>
+    {% if create_view_url %}
+        <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+            <a class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
+        </div>
+    {% endif %}
 </div>
 
 {% if object_list %}

--- a/src/neapolitan/templates/neapolitan/object_list.html
+++ b/src/neapolitan/templates/neapolitan/object_list.html
@@ -6,10 +6,10 @@
 <div class="sm:flex sm:items-center">
     <h1 class="sm:flex-auto text-base font-semibold leading-6 text-gray-900">{{ object_verbose_name_plural|capfirst }}</h1>
     {% if create_view_url %}
-        <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-            <a class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-              href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
-        </div>
+    <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+        <a class="block rounded-md bg-indigo-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+          href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
+    </div>
     {% endif %}
 </div>
 

--- a/src/neapolitan/templatetags/neapolitan.py
+++ b/src/neapolitan/templatetags/neapolitan.py
@@ -8,10 +8,14 @@ register = template.Library()
 
 def action_links(view, object):
     actions = [
-        (Role.DETAIL.reverse(view, object), "View"),
-        (Role.UPDATE.reverse(view, object), "Edit"),
-        (Role.DELETE.reverse(view, object), "Delete"),
+        (url, name)
+        for url, name in [
+            (Role.DETAIL.reverse(view, object), "View"),
+            (Role.UPDATE.reverse(view, object), "Edit"),
+            (Role.DELETE.reverse(view, object), "Delete"),
+        ] if url is not None
     ]
+
     links = [f"<a href='{url}'>{anchor_text}</a>" for url, anchor_text in actions]
     return mark_safe(" | ".join(links))
 

--- a/src/neapolitan/templatetags/neapolitan.py
+++ b/src/neapolitan/templatetags/neapolitan.py
@@ -10,12 +10,11 @@ def action_links(view, object):
     actions = [
         (url, name)
         for url, name in [
-            (Role.DETAIL.reverse(view, object), "View"),
-            (Role.UPDATE.reverse(view, object), "Edit"),
-            (Role.DELETE.reverse(view, object), "Delete"),
+            (Role.DETAIL.maybe_reverse(view, object), "View"),
+            (Role.UPDATE.maybe_reverse(view, object), "Edit"),
+            (Role.DELETE.maybe_reverse(view, object), "Delete"),
         ] if url is not None
     ]
-
     links = [f"<a href='{url}'>{anchor_text}</a>" for url, anchor_text in actions]
     return mark_safe(" | ".join(links))
 

--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -6,7 +6,7 @@ from django.forms import models as model_forms
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
-from django.urls import path, reverse
+from django.urls import path, reverse, NoReverseMatch
 from django.utils.decorators import classonlymethod
 from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
@@ -88,15 +88,17 @@ class Role(enum.Enum):
     def reverse(self, view, object=None):
         url_name = f"{view.url_base}-{self.url_name_component}"
         url_kwarg = view.lookup_url_kwarg or view.lookup_field
-        match self:
-            case Role.LIST | Role.CREATE:
-                return reverse(url_name)
-            case _:
-                return reverse(
-                    url_name,
-                    kwargs={url_kwarg: getattr(object, view.lookup_field)},
-                )
-
+        try:
+            match self:
+                case Role.LIST | Role.CREATE:
+                    return reverse(url_name)
+                case _:
+                    return reverse(
+                        url_name,
+                        kwargs={url_kwarg: getattr(object, view.lookup_field)},
+                    )
+        except NoReverseMatch:
+            return None
 
 
 class CRUDView(View):
@@ -371,7 +373,10 @@ class CRUDView(View):
         kwargs["view"] = self
         kwargs["object_verbose_name"] = self.model._meta.verbose_name
         kwargs["object_verbose_name_plural"] = self.model._meta.verbose_name_plural
-        kwargs["create_view_url"] = reverse(f"{self.url_base}-create")
+        try:
+            kwargs["create_view_url"] = reverse(f"{self.url_base}-create")
+        except NoReverseMatch:
+            kwargs["create_view_url"] = None
 
         if getattr(self, "object", None) is not None:
             kwargs["object"] = self.object

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -27,9 +27,15 @@ class NamedCollectionView(CRUDView):
     url_base = "named_collections"
 
 
+class BookmarkListOnlyView(CRUDView):
+    model = Bookmark
+    url_base = "bookmarklist"
+
+
 urlpatterns = [
     *BookmarkView.get_urls(),
     *NamedCollectionView.get_urls(),
+    *BookmarkListOnlyView.get_urls({Role.LIST}),
 ]
 
 
@@ -231,6 +237,13 @@ class RoleTests(TestCase):
     def test_routing_subset_of_roles(self):
         urlpatterns = BookmarkView.get_urls(roles={Role.LIST, Role.DETAIL})
         self.assertEqual(len(urlpatterns), 2)
+
+    def test_rendering_list_only_role(self):
+        response = self.client.get('/bookmarklist/')
+        self.assertEqual(response.status_code, 200)
+
+        for lookup in ['View', 'Edit', 'Delete']:
+            self.assertNotContains(response, f'>{lookup}</a>')
 
 
 class MktemplateCommandTest(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,6 +29,7 @@ class NamedCollectionView(CRUDView):
 
 class BookmarkListOnlyView(CRUDView):
     model = Bookmark
+    fields = ["url", "title", "note"]
     url_base = "bookmarklist"
 
 
@@ -239,6 +240,12 @@ class RoleTests(TestCase):
         self.assertEqual(len(urlpatterns), 2)
 
     def test_rendering_list_only_role(self):
+        bookmark = Bookmark.objects.create(
+            url="https://noumenal.es/",
+            title="Noumenal • Dr Carlton Gibson",
+            note="Carlton Gibson's homepage. Blog, Contact and Project links.",
+            favourite=True,
+        )
         response = self.client.get('/bookmarklist/')
         self.assertEqual(response.status_code, 200)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.html import escape
-from neapolitan.views import CRUDView, Role
+from neapolitan.views import CRUDView, Role, classonlymethod
 
 from .models import Bookmark, NamedCollection
 
@@ -32,11 +32,15 @@ class BookmarkListOnlyView(CRUDView):
     fields = ["url", "title", "note"]
     url_base = "bookmarklist"
 
+    @classonlymethod
+    def get_urls(cls, roles=None):
+        return super().get_urls(roles={Role.LIST})
+
 
 urlpatterns = [
     *BookmarkView.get_urls(),
     *NamedCollectionView.get_urls(),
-    *BookmarkListOnlyView.get_urls({Role.LIST}),
+    *BookmarkListOnlyView.get_urls(),
 ]
 
 


### PR DESCRIPTION
Hey @carltongibson ,

here's the (initial?) PR for #46 with the changes discussed in the issue.

While creating this PR though, I noticed it was rather straightforward to **remove** actions but that adding an action (ie: duplicate, archive, open, ...) would be rather complicated due to the nature of `Role` that cannot be extended.

I am thinking about refactoring `Role` to be more flexible (either not an `Enum` anymore or implementing something like a `role_factory`). It would probably be best left in its own PR but it could very well be included here too.