### PR TITLE
added list_view_url to the get_context_data

### DIFF
--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -377,7 +377,8 @@ class CRUDView(View):
         kwargs["object_verbose_name"] = self.model._meta.verbose_name
         kwargs["object_verbose_name_plural"] = self.model._meta.verbose_name_plural
         kwargs["create_view_url"] = Role.CREATE.maybe_reverse(self)
-
+        kwargs["list_view_url"] = Role.LIST.maybe_reverse(self)
+        
         if getattr(self, "object", None) is not None:
             kwargs["object"] = self.object
             context_object_name = self.get_context_object_name()


### PR DESCRIPTION
Many times, when using the Create, Read or Update views, I need a quick way of going back to the list view. I saw that the get_context_data had a "create_view_url" in it, but not a "list_view_url", so I have just added that to the context. So that now, in the templates, I can use this list_view_url to create another button to either cancel the Creation or Update, or to just go back to the ListView

This is the only change made