### PR TITLE
Refactor action links for easier template customization

### DIFF
--- a/src/neapolitan/templates/neapolitan/partial/list.html
+++ b/src/neapolitan/templates/neapolitan/partial/list.html
@@ -27,8 +27,10 @@
                   {% endif %}
                   ">{{ field }}</td>
     {% endfor %}
-        <td class="py-3.5 px-3 text-right text-sm font-medium [&_a]:text-indigo-600 [&_a:hover]:text-indigo-900">
-            {{ object.actions }}
+        <td class="py-3.5 px-3 space-x-3 text-right text-sm font-medium [&_a]:text-indigo-600 [&_a:hover]:text-indigo-900">
+            {% for action in object.actions %}
+                    <a href="{{ action.URL }}">{{ action.Name }}</a>
+            {% endfor %}
         </td>
 </tr>
 {% endfor %}

--- a/src/neapolitan/templatetags/neapolitan.py
+++ b/src/neapolitan/templatetags/neapolitan.py
@@ -8,15 +8,14 @@ register = template.Library()
 
 def action_links(view, object):
     actions = [
-        (url, name)
+        {"Name": name, "URL": url}
         for url, name in [
             (Role.DETAIL.maybe_reverse(view, object), "View"),
             (Role.UPDATE.maybe_reverse(view, object), "Edit"),
             (Role.DELETE.maybe_reverse(view, object), "Delete"),
         ] if url is not None
     ]
-    links = [f"<a href='{url}'>{anchor_text}</a>" for url, anchor_text in actions]
-    return mark_safe(" | ".join(links))
+    return actions
 
 
 @register.inclusion_tag("neapolitan/partial/detail.html")


### PR DESCRIPTION
- Replace Python template tags with a for loop in HTML
- Change action structure from tuple to dictionary
- Remove HTML generation in Python code
- Allow direct rendering of action properties in template