### PR TITLE
Fix filterset to be unbound when no GET parameters are passed

### DIFF
--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -351,7 +351,7 @@ class CRUDView(View):
             return None
 
         return filterset_class(
-            self.request.GET,
+            self.request.GET or None, # None is required for the filterset to be unbound
             queryset=queryset,
             request=self.request,
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -72,6 +72,10 @@ class BasicTests(TestCase):
         response = self.client.get("/bookmark/")
         self.assertEqual(response.status_code, 200)
         self.assertIn("filterset", response.context)
+        filterset = response.context["filterset"]
+        # no filtering was done, so the filterset (and it's form) should not be bound
+        self.assertFalse(filterset.is_bound)
+        self.assertFalse(filterset.form.is_bound)
         self.assertContains(response, self.homepage.title)
         self.assertContains(response, self.github.title)
         self.assertContains(response, self.fosstodon.title)


### PR DESCRIPTION
Fix the filterset to be unbound on a request with no get parameters.

This is necessary to set the filterset's (and it's form) initial values. 

See
https://github.com/carltongibson/django-filter/blob/635343ec55c9928bfa297314711df77fa83ff6c7/django_filters/filterset.py#L198