### PR TITLE
Running tests against supported Python versions (#83)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0", "main"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        django-version: ["4.2", "5.2", "main"]
+        exclude:
+          - python-version: "3.13"
+            django-version: "4.2"
+          - python-version: "3.10"
+            django-version: "main"
+          - python-version: "3.11"
+            django-version: "main"
     steps:
       - uses: actions/checkout@v4
 

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,18 @@ Versioning and Status
 Neapolitan uses a two-part CalVer versioning scheme, such as ``23.7``. The first
 number is the year. The second is the release number within that year.
 
+On an on-going basis, Neapolitan aims to support all current Django
+versions and the matching current Python versions.
+
+Please see:
+
+* `Status of supported Python versions <https://devguide.python.org/versions/#supported-versions>`_
+* `List of supported Django versions <https://www.djangoproject.com/download/#supported-versions>`_
+
+Support for Python and Django versions will be dropped when they reach
+end-of-life. Support for Python versions will be dropped when they reach
+end-of-life, even when still supported by a current version of Django.
+
 This is alpha software. I'm still working out the details of the API, and I've
 only begun the docs.
 


### PR DESCRIPTION
Issue #83 points to a GitHub action failing, because the current Django `main` requires Python >= 3.12.

This PR assumes that we not only want to have a passing pipeline, but rather a Django / Python compatibility guarantee for Neapolitan.

- Therefore, I took the compatibility note of `django-filter` and kept everything but the DRF reference.
- Changed the matrix to the current Django LTS and corresponding Python version,
- **but** ditched Python 3.9 (for Django 4.2) as it would require us to remove the beautiful `match` statements and is eol in October anyways. (No further changes would be required to support Python 3.9)
- No Python (deprecation) warnings need to be addressed.