### PR TITLE
Fix mktemplate attribute error

### DIFF
--- a/src/neapolitan/management/commands/mktemplate.py
+++ b/src/neapolitan/management/commands/mktemplate.py
@@ -6,6 +6,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import TemplateDoesNotExist, get_template
 from django.template.engine import Engine
 from django.apps import apps
+from django.conf import settings
+
 
 class Command(BaseCommand):
     help = "Bootstrap a CRUD template for a model, copying from the active neapolitan default templates."
@@ -64,8 +66,37 @@ class Command(BaseCommand):
             dest="role",
             help="Delete role",
         )
+        group.add_argument(
+            "--all",
+            action="store_const",
+            const="all",
+            dest="role",
+            help="Generate all CRUD templates (list, detail, form, delete)",
+        )
 
     def handle(self, *args, **options):
+        model = options["model"]
+        role = options["role"]
+
+        # Handle --all option
+        if role == "all":
+            roles = ["list", "detail", "form", "delete"]
+            for r in roles:
+                options["role"] = r
+                try:
+                    self._handle_single_template(*args, **options)
+                except CommandError as e:
+                    # Continue with other templates even if one exists
+                    if "already exists" in str(e):
+                        continue
+                    else:
+                        raise
+            return
+
+        # Handle single template
+        self._handle_single_template(*args, **options)
+
+    def _handle_single_template(self, *args, **options):
         model = options["model"]
         role = options["role"]
 
@@ -97,13 +128,26 @@ class Command(BaseCommand):
             target_dir = f"{app_config.path}/templates"
             if not Path(target_dir).exists():
                 try:
-                    target_dir = Engine.get_default().template_dirs[0]
-                except (ImproperlyConfigured, IndexError):
-                    raise CommandError(
-                        "No app or project level template dir found."
-                    )
+                    # FIX: Access DIRS from the template settings instead of template_dirs
+                    template_settings = settings.TEMPLATES[0]
+                    if template_settings.get('DIRS'):
+                        target_dir = template_settings['DIRS'][0]
+                    else:
+                        # No project-level template dir, so create app-level templates
+                        target_dir = f"{app_config.path}/templates"
+                except (ImproperlyConfigured, IndexError, KeyError):
+                    # Fallback to creating app-level templates
+                    target_dir = f"{app_config.path}/templates"
+
+            # Ensure the full directory path exists
+            target_path = Path(target_dir) / Path(template_name).parent
+            target_path.mkdir(parents=True, exist_ok=True)
+
             # Copy the neapolitan template to the target directory with template_name.
             shutil.copyfile(neapolitan_template_path, f"{target_dir}/{template_name}")
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully created template: {target_dir}/{template_name}")
+            )
         else:
             self.stdout.write(
                 f"Template {template_name} already exists. Remove it manually if you want to regenerate it."

--- a/src/neapolitan/management/commands/mktemplate.py
+++ b/src/neapolitan/management/commands/mktemplate.py
@@ -6,6 +6,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import TemplateDoesNotExist, get_template
 from django.template.engine import Engine
 from django.apps import apps
+from django.conf import settings
+
 
 class Command(BaseCommand):
     help = "Bootstrap a CRUD template for a model, copying from the active neapolitan default templates."
@@ -64,8 +66,38 @@ class Command(BaseCommand):
             dest="role",
             help="Delete role",
         )
+        group.add_argument(
+            "-a",
+            "--all",
+            action="store_const",
+            const="all",
+            dest="role",
+            help="Generate all CRUD templates (list, detail, form, delete)",
+        )
 
     def handle(self, *args, **options):
+        model = options["model"]
+        role = options["role"]
+
+        # Handle --all option
+        if role == "all":
+            roles = ["list", "detail", "form", "delete"]
+            for r in roles:
+                options["role"] = r
+                try:
+                    self._handle_single_template(*args, **options)
+                except CommandError as e:
+                    # Continue with other templates even if one exists
+                    if "already exists" in str(e):
+                        continue
+                    else:
+                        raise
+            return
+
+        # Handle single template
+        self._handle_single_template(*args, **options)
+
+    def _handle_single_template(self, *args, **options):
         model = options["model"]
         role = options["role"]
 
@@ -97,13 +129,26 @@ class Command(BaseCommand):
             target_dir = f"{app_config.path}/templates"
             if not Path(target_dir).exists():
                 try:
-                    target_dir = Engine.get_default().template_dirs[0]
-                except (ImproperlyConfigured, IndexError):
-                    raise CommandError(
-                        "No app or project level template dir found."
-                    )
+                    # FIX: Access DIRS from the template settings instead of template_dirs
+                    template_settings = settings.TEMPLATES[0]
+                    if template_settings.get('DIRS'):
+                        target_dir = template_settings['DIRS'][0]
+                    else:
+                        # No project-level template dir, so create app-level templates
+                        target_dir = f"{app_config.path}/templates"
+                except (ImproperlyConfigured, IndexError, KeyError):
+                    # Fallback to creating app-level templates
+                    target_dir = f"{app_config.path}/templates"
+
+            # Ensure the full directory path exists
+            target_path = Path(target_dir) / Path(template_name).parent
+            target_path.mkdir(parents=True, exist_ok=True)
+
             # Copy the neapolitan template to the target directory with template_name.
             shutil.copyfile(neapolitan_template_path, f"{target_dir}/{template_name}")
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully created template: {target_dir}/{template_name}")
+            )
         else:
             self.stdout.write(
                 f"Template {template_name} already exists. Remove it manually if you want to regenerate it."

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -331,3 +331,21 @@ class MktemplateCommandTest(TestCase):
 
         # Remove the created file
         os.remove(file_path)
+
+    def test_mktemplate_all_command(self):
+        # Run the command with --all
+        call_command("mktemplate", "tests.Bookmark", "--all")
+
+        # Check if all files were created
+        expected_files = [
+            "tests/templates/tests/bookmark_list.html",
+            "tests/templates/tests/bookmark_detail.html",
+            "tests/templates/tests/bookmark_form.html",
+            "tests/templates/tests/bookmark_confirm_delete.html",
+        ]
+
+        for file_path in expected_files:
+            self.assertTrue(os.path.isfile(file_path))
+            # Clean up
+            os.remove(file_path)
+


### PR DESCRIPTION
## Bug Description
The mktemplate command fails when there's no app-level templates directory already existing: `AttributeError: 'Engine' object has no attribute 'template_dirs'`

This happens as the command looks for a pre-existing `app/template/app` location.

## Proposed Solution
I have a fix ready that:
- Keeps current check if `app/templates/app` directory exists, if not then:
-- Uses `settings.TEMPLATES[0]['DIRS']` to see if project level templates exist (**new**)
-- If neither exist, creates app-level templates directory (**new**)
-- Adds `-a/--all` option to generate all CRUD templates at once (**new**)
- Updated tests to ensure coverage

## Environment Tested
- Django 5.2.3
- Django 4.2.23
- neapolitan 24.8

## Note
Since you use app-level templates, this now auto-creates the `app/templates/app/` structure when bootstrapping a new app - no more manual mkdir! Still respects project-level templates for those who prefer that approach.
