### PR TITLE
Using Role url reversal to support all custom lookup_fields (#86)

### DIFF
--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -296,11 +296,9 @@ class CRUDView(View):
             % self.__class__.__name__
         )
         if self.role == Role.DELETE:
-            success_url = reverse(f"{self.url_base}-list")
+            success_url = Role.LIST.reverse(self)
         else:
-            success_url = reverse(
-                f"{self.url_base}-detail", kwargs={"pk": self.object.pk}
-            )
+            success_url = Role.DETAIL.reverse(self, self.object)
         return success_url
 
     # Pagination and filtering

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from django.core.management import call_command
 from django.http import HttpResponse
@@ -167,6 +168,21 @@ class BasicTests(TestCase):
         response = self.client.get(f"/named_collections/{self.main_collection.code}/")
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.main_collection.name)
+
+    def test_custom_lookup_field_create(self):
+        create_url = reverse("named_collections-create")
+
+        # Submit the form.
+        response = self.client.post(
+            create_url,
+            {
+                "code": uuid.uuid4(),
+                "name": "The Carlton Collection",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "named_collections-detail")
 
     def test_lookup_url_converter(self):
         """Test view.lookup_url_converter"""


### PR DESCRIPTION
Using the Roles url reversal capabilities to support custom `lookup_fields` (and other **future** customisations).
fixes #86 

I tried sticking with the current test structure:
- used the request / response testing instead of testing `get_success_url` directly
- did not test the creation form get as it is unrelated to the issue
- made sure the test actually fails without the changes of this PR
- ... and the collection name has to fit the bookmarks of the tests, right?

To prevent errors of this category, I also checked the code for other locations of manually reversing urls. There aren't any.
(I did that yesterday when I discovered the same problem when subclassing Neapolitan components to properly support nested views. So #86 felt like a call to action. 😅)

