### PR TITLE
Add missing update_view_url to object_form context and fix template docs

### DIFF
--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -64,15 +64,29 @@ See ``python manage.py mktemplate --help`` for full details.
 
 Used for both the create and update views.
 
-``neapolitan/object_list.html``
+``neapolitan/object_form.html``
 
 Context variables:
 
-* ``object``: the object being updated, if present.
+* ``object``: the object being updated (for the update view)
 * ``object_verbose_name``: the verbose name of the object, e.g. ``bookmark``.
 * ``form``: the form.
 * ``create_view_url``: the URL for the create view.
 * ``update_view_url``: the URL for the update view.
+
+``object_list.html``
+--------------------
+
+Used for the list view.
+
+``neapolitan/object_list.html``
+
+Context variables:
+
+* ``object_list``: the list of objects.
+* ``object_verbose_name``: the verbose name of the object, e.g. ``bookmark``.
+* ``object_verbose_name_plural``: the plural verbose name, e.g. ``bookmarks``.
+* ``create_view_url``: the URL for the create view.
 
 ``object_confirm_delete.html``
 ------------------------------

--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -378,6 +378,7 @@ class CRUDView(View):
 
         if getattr(self, "object", None) is not None:
             kwargs["object"] = self.object
+            kwargs["update_view_url"] = Role.UPDATE.maybe_reverse(self, self.object)
             context_object_name = self.get_context_object_name()
             if context_object_name:
                 kwargs[context_object_name] = self.object

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,6 +136,7 @@ class BasicTests(TestCase):
         # Load the form.
         response = self.client.get(update_url)
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'action="/bookmark/{self.homepage.pk}/edit/"')
 
         # Submit the form.
         response = self.client.post(


### PR DESCRIPTION
The object_form.html template referenced update_view_url but it was never added to the view context.