### PR TITLE
Making Role.reverse URL namespace aware

### DIFF
--- a/src/neapolitan/views.py
+++ b/src/neapolitan/views.py
@@ -1,4 +1,5 @@
 import enum
+from contextlib import suppress
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import InvalidPage, Paginator
@@ -88,6 +89,12 @@ class Role(enum.Enum):
     def reverse(self, view, object=None):
         url_name = f"{view.url_base}-{self.url_name_component}"
         url_kwarg = view.lookup_url_kwarg or view.lookup_field
+
+        with suppress(AttributeError):
+            url_namespace = view.request.resolver_match.namespace
+            if url_namespace:
+                url_name = f"{url_namespace}:{url_name}"
+
         match self:
             case Role.LIST | Role.CREATE:
                 return reverse(url_name)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,7 +4,7 @@ import uuid
 from django.core.management import call_command
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
-from django.urls import reverse
+from django.urls import reverse, path, include
 from django.utils.html import escape
 
 from neapolitan.views import CRUDView, Role, classonlymethod
@@ -45,11 +45,15 @@ class BookmarkTagView(CRUDView):
     fields = ["bookmark", "tag"]
 
 
+app_urlpatterns = ([*BookmarkView.get_urls()], "bookmarks")
+
 urlpatterns = [
     *BookmarkView.get_urls(),
     *NamedCollectionView.get_urls(),
     *BookmarkListOnlyView.get_urls(),
     *BookmarkTagView.get_urls(),
+    path("namespaced/", include(app_urlpatterns, namespace="public")),
+    path("namespacedImplicitly/", include(app_urlpatterns)),
 ]
 
 
@@ -277,6 +281,58 @@ class RoleTests(TestCase):
             with self.subTest(role=role):
                 self.assertEqual(
                     role.reverse(BookmarkView, bookmark),
+                    url,
+                )
+
+    def test_role_namespaced_url_reversing(self):
+        bookmark = Bookmark.objects.create(
+            url="https://noumenal.es/",
+            title="Noumenal • Dr Carlton Gibson",
+            note="Carlton Gibson's homepage. Blog, Contact and Project links.",
+            favourite=True,
+        )
+        tests = [
+            (Role.LIST, "/namespaced/bookmark/"),
+            (Role.DETAIL, f"/namespaced/bookmark/{bookmark.pk}/"),
+            (Role.CREATE, "/namespaced/bookmark/new/"),
+            (Role.UPDATE, f"/namespaced/bookmark/{bookmark.pk}/edit/"),
+            (Role.DELETE, f"/namespaced/bookmark/{bookmark.pk}/delete/"),
+        ]
+
+        response = self.client.get("/namespaced/bookmark/")
+        self.assertEqual(response.status_code, 200)
+        view = response.context["view"]
+
+        for role, url in tests:
+            with self.subTest(role=role):
+                self.assertEqual(
+                    role.reverse(view, bookmark),
+                    url,
+                )
+
+    def test_role_app_url_reversing(self):
+        bookmark = Bookmark.objects.create(
+            url="https://noumenal.es/",
+            title="Noumenal • Dr Carlton Gibson",
+            note="Carlton Gibson's homepage. Blog, Contact and Project links.",
+            favourite=True,
+        )
+        tests = [
+            (Role.LIST, "/namespacedImplicitly/bookmark/"),
+            (Role.DETAIL, f"/namespacedImplicitly/bookmark/{bookmark.pk}/"),
+            (Role.CREATE, "/namespacedImplicitly/bookmark/new/"),
+            (Role.UPDATE, f"/namespacedImplicitly/bookmark/{bookmark.pk}/edit/"),
+            (Role.DELETE, f"/namespacedImplicitly/bookmark/{bookmark.pk}/delete/"),
+        ]
+
+        response = self.client.get("/namespacedImplicitly/bookmark/")
+        self.assertEqual(response.status_code, 200)
+        view = response.context["view"]
+
+        for role, url in tests:
+            with self.subTest(role=role):
+                self.assertEqual(
+                    role.reverse(view, bookmark),
                     url,
                 )
 


### PR DESCRIPTION
URL namespaces now work with Neapolitan's CRUD views. You can mount a `CRUDView` under a namespace and `Role.reverse` will resolve to the correct URLs.

For that to work `reverse` needs to be called with a dispatched view instance (so it can read `request.resolver_match`). Neapolitan is doing that, but a consumer might not. Calling it with a class still works but skips namespace resolution. The existing [`test_role_url_reversing` test](https://github.com/carltongibson/neapolitan/blob/3c529c4a60579e695942edabc446cf9c04ea0803/tests/tests.py#L279) is excersing that fallback.

I considered a `warnings.warn()` for the missing `resolver_match` case and rejected it. In normal request flow resolver_match is always set, so the warning would only fire in non-dispatched contexts (e.g., calling `Role.reverse()` with a view class, as in `test_role_url_reversing`). For users who don't use namespaces at all, that warning would be pure noise, they'd see warnings for behavior that is intentionally and silently a no-op for them. The fallback to an empty namespace is enough; if a caller actually needed a namespace, `reverse()` will raise `NoReverseMatch`, which is a sufficiently loud signal.

The introduced tests cover the registration of `CRUDView`s within implicit and explicit namespaces. By doing that we are also asserting that registering the same view in multiple namespaces works.

## Deviations from prior discussions
I am deviating from our discussion that resulted in [this comment on #16](https://github.com/carltongibson/neapolitan/issues/16#issuecomment-4273677347):
- not introducing a `url_namespace` parameter to any Neapolitan component, because it would duplicate Django functionality.
- Assuming we would introduce `url_namespace` we also would need to introduce an `app_name` parameter to properly replicate [Django's URL reversal behaviour](https://github.com/carltongibson/neapolitan/blob/3c529c4a60579e695942edabc446cf9c04ea0803/tests/tests.py#L279).
- not introducing a `crud_url` template tag as you are able to use namespaces like you would in any non-Neapolitan codebase

## Documentation
I considered adding documentation to either (1) CRUDView Reference > URLs and view callables and (2) How Tos. I decided against that because (1) would say 'do what you are always doing, Neapolitan works with that' and (2) would repeat (parts of) [Django's URL namespaces](https://docs.djangoproject.com/en/6.0/topics/http/urls/#url-namespaces) documentation.

## Open Questions for Review
1. Do you agree that the design goals of supporting URL namespaces are actually fullfiled?
2. Do you deem the implicit change of requiring a view instance during reversal as acceptable?
3. Is my argument about documentation sound? Should there be some documentation?
4. The tests file is getting somewhat long. Should that be addressed before merging this PR?